### PR TITLE
Update README to have correct install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
 ```
 $ go get github.com/cloudfoundry-community/cf-plugin-open
-$ cf install-plugin $GOPATH/bin/open
+$ cf install-plugin $GOPATH/bin/cf-plugin-open
 ```
 
 Usage


### PR DESCRIPTION
The binary created is called `cf-plugin-open` rather than `open` so the `cf install-plugin` instructions were incorrect. Updated the README.md to the correct instructions.