### PR TITLE
use S&W code signing cert to sign binaries before they go out

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -263,6 +263,9 @@ jobs:
               CMD_PKG:      (( grab meta.go.cmd_module ))
               STATIC_BINARY: (( grab meta.go.force_static_binary ))
               TARGETS:       (( grab meta.shipit.targets ))
+              KEY_PASS:      (( grab meta.csc.key_pass ))
+              STORE_PASS:    (( grab meta.csc.store_pass ))
+              JKS:           (( grab meta.csc.jks ))
         - name: version
           put: version
           params: { bump: final }

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -61,6 +61,17 @@ gox -osarch="${TARGETS}" --output="artifacts/${BINARY}-{{.OS}}-{{.Arch}}" -ldfla
 go build -o "${BINARY}" -ldflags="-X main.Version=${VERSION}" ${CMD_PKG:-.}
 ./${BINARY} -v
 
+(apt-get update && apt-get install -y openjdk-8-jdk) &>/dev/null
+
+pushd artifacts
+for file in *
+do
+  zip -m ${file}.zip ${file}
+  jarsigner -tsa http://timestamp.digicert.com -keystore "${JKS}" -storepass "${STORE_PASS}" -keypass "${KEY_PASS}" ${file}.zip "key from www.digicert.com"
+  zip -d ${file}.zip 'META-INF/*' > /dev/null 2>&1
+done
+popd
+
 ls artifacts/* | xargs -L1 sha1sum
 popd
 

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -14,6 +14,11 @@ meta:
     access_key: (( vault "secret/aws/cfcommunity:access" ))
     secret_key: (( vault "secret/aws/cfcommunity:secret" ))
 
+  csc:
+    key_pass:   (( vault "secret/csc:key_pass" ))
+    store_pass: (( vault "secret/csc:store_pass" ))
+    jks:        (( vault "secret/csc:jks" ))
+
   github:
     owner:  cloudfoundry-community
     repo:   cf-plugin-open


### PR DESCRIPTION
Sign the binaries for Windows, Mac and Linux using S&W code signing cert.